### PR TITLE
Remove invalid item from `depends` property in library metadata

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=This Arduino library makes it easy to use rotary encoders. A few lines
 category=Other
 url=https://github.com/gianni-carbone/STM32encoder
 architectures=stm32
-depends=STM32duino
+depends=


### PR DESCRIPTION
The `depends` property of the [`library.properties` metadata file](https://arduino.github.io/arduino-cli/latest/library-specification/#library-metadata) specifies the library dependencies that should be installed by [Arduino Library Manager](https://docs.arduino.cc/software/ide-v2/tutorials/ide-v2-installing-a-library#installing-a-library) along with the library.

This field must contain only names of libraries that are available for installation via Library Manager.

Previously, the presence of this item not in Library Manager caused installation of the library to fail:

- Arduino IDE 1.x: "`java.net.MalformedURLException: no protocol: [...]`" error
- Arduino IDE 2.x: "`No valid dependencies solution found: [...]`" error
- Arduino CLI: "`No valid dependencies solution found: [...]`" error

The removal of the item will allow the next release of the library to be installed via Library Manager.

---

Originally reported at https://forum.arduino.cc/t/dependency-stm32-is-not-available/1195285